### PR TITLE
Merge recent unit test changes into PERTY_py

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,4 +6,4 @@ ADD . /PERTY_py
 
 RUN pip install -r requirements.txt
 
-CMD ["python", "UnitTest_pert.py"]
+CMD ["python", "UnitTest_main.py"]

--- a/python/UnitTest_main.py
+++ b/python/UnitTest_main.py
@@ -1,0 +1,12 @@
+##THIS IS THE UNIT TEST DRIVER PROGRAM. ADD ALL YOUR TEST CLASSES HERE TO BE TESTED
+
+import unittest
+from UnitTest_pert import pertEquationTests
+from UnitTest_tasklist import taskListOperationTests
+
+suiteList = []
+suiteList.append(unittest.TestLoader().loadTestsFromTestCase(pertEquationTests))
+suiteList.append(unittest.TestLoader().loadTestsFromTestCase(taskListOperationTests))
+
+combinedSuite = unittest.TestSuite(suiteList)
+unittest.TextTestRunner(verbosity=0).run(combinedSuite)

--- a/python/UnitTest_pert.py
+++ b/python/UnitTest_pert.py
@@ -1,6 +1,5 @@
 import unittest
 from task import Task
-from tasklist import TaskList
 
 class pertEquationTests(unittest.TestCase):
     def test_expectedDurationCalculation(self):
@@ -58,40 +57,6 @@ class pertEquationTests(unittest.TestCase):
 
         worstCasePriority = taskA.weight/taskA.worstCase
         self.assertEqual(worstCasePriority, taskA.priorityWorst)
-
-    def test_addTaskToTaskList(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-        taskB = Task(1.0, 1.5, 14.0, 4)
-
-        taskList = TaskList();
-        self.assertEqual(taskList.taskCount, 0) #Originally no items.
-        taskList.addTask(taskA)
-        taskList.addTask(taskB)
-        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
-
-    def test_removeTaskFromTaskList(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-        taskB = Task(1.0, 1.5, 14.0, 4)
-
-        taskList = TaskList();
-        self.assertEqual(taskList.taskCount, 0) #Originally no items.
-        taskList.addTask(taskA)
-        taskList.addTask(taskB)
-        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
-
-        taskList.removeTask(taskA)
-        self.assertEqual(taskList.taskCount, 1)
-        taskList.removeTask(taskB)
-        self.assertEqual(taskList.taskCount, 0)
-
 
 
 if __name__ == '__main__':

--- a/python/UnitTest_pert.py
+++ b/python/UnitTest_pert.py
@@ -2,62 +2,40 @@ import unittest
 from task import Task
 
 class pertEquationTests(unittest.TestCase):
+
+    def setUp(self):
+        self.estimate = 3.0
+        self.optimistic = 1.0
+        self.pessimistic = 12.0
+
+        self.taskA = Task(self.optimistic, self.estimate, self.pessimistic, 3)
+
+    def tearDown(self):
+        self.estimate = 0
+        self.optimistic = 0
+        self.pessimistic = 0
+        self.taskA = None
+
     def test_expectedDurationCalculation(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-
-        self.assertEqual(4.17, taskA.expected)
+        self.assertEqual(4.17, self.taskA.expected)
 
     def test_standardDeviationCalculation(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-
-        self.assertEqual(1.83, taskA.stdDev)
+        self.assertEqual(1.83, self.taskA.stdDev)
 
     def test_bestCaseEstimate(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-
-        bestCaseEstimate_value = taskA.expected - (taskA.multiplier * taskA.stdDev)
-
-        self.assertEqual(bestCaseEstimate_value, taskA.bestCase)
+        bestCaseEstimate_value = self.taskA.expected - (self.taskA.multiplier * self.taskA.stdDev)
+        self.assertEqual(bestCaseEstimate_value, self.taskA.bestCase)
 
     def test_worstCaseEstimate(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-
-        worstCaseEstimate_value = taskA.expected + (taskA.multiplier * taskA.stdDev)
-
-        self.assertEqual(worstCaseEstimate_value, taskA.worstCase)
+        worstCaseEstimate_value = self.taskA.expected + (self.taskA.multiplier * self.taskA.stdDev)
+        self.assertEqual(worstCaseEstimate_value, self.taskA.worstCase)
 
     def test_priorityCalculation(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
+        bestCasePriority = self.taskA.weight/self.taskA.bestCase
+        self.assertEqual(bestCasePriority, self.taskA.priorityBest)
 
-        taskA = Task(optimistic, estimate, pessimistic, 3)
+        expectedDurationPriority = self.taskA.weight/self.taskA.expected
+        self.assertEqual(expectedDurationPriority, self.taskA.priorityExpected)
 
-        bestCasePriority = taskA.weight/taskA.bestCase
-        self.assertEqual(bestCasePriority, taskA.priorityBest)
-
-        expectedDurationPriority = taskA.weight/taskA.expected
-        self.assertEqual(expectedDurationPriority, taskA.priorityExpected)
-
-        worstCasePriority = taskA.weight/taskA.worstCase
-        self.assertEqual(worstCasePriority, taskA.priorityWorst)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        worstCasePriority = self.taskA.weight/self.taskA.worstCase
+        self.assertEqual(worstCasePriority, self.taskA.priorityWorst)

--- a/python/UnitTest_tasklist.py
+++ b/python/UnitTest_tasklist.py
@@ -3,38 +3,42 @@ from task import Task
 from tasklist import TaskList
 
 class taskListOperationTests(unittest.TestCase):
+
+    def setUp(self):
+        self.estimate = 3.0
+        self.optimistic = 1.0
+        self.pessimistic = 12.0
+
+        self.taskA = Task(self.optimistic, self.estimate, self.pessimistic, 3)
+        self.taskB = Task(1.0, 1.5, 14.0, 4)
+
+        self.taskList = TaskList();
+
+    def tearDown(self):
+        self.estimate = 0
+        self.optimistic = 0
+        self.pessimistic = 0
+
+        self.taskA = None
+        self.taskB = None
+        self.taskList = None
+
     def test_addTaskToTaskList(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
-
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-        taskB = Task(1.0, 1.5, 14.0, 4)
-
-        taskList = TaskList();
-        self.assertEqual(taskList.taskCount, 0) #Originally no items.
-        taskList.addTask(taskA)
-        taskList.addTask(taskB)
-        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
+        self.assertEqual(self.taskList.taskCount, 0) #Originally no items.
+        self.taskList.addTask(self.taskA)
+        self.taskList.addTask(self.taskB)
+        self.assertEqual(self.taskList.taskCount, 2) #Now two should exist.
 
     def test_removeTaskFromTaskList(self):
-        estimate = 3.0
-        optimistic = 1.0
-        pessimistic = 12.0
+        self.assertEqual(self.taskList.taskCount, 0) #Originally no items.
+        self.taskList.addTask(self.taskA)
+        self.taskList.addTask(self.taskB)
+        self.assertEqual(self.taskList.taskCount, 2) #Now two should exist.
 
-        taskA = Task(optimistic, estimate, pessimistic, 3)
-        taskB = Task(1.0, 1.5, 14.0, 4)
-
-        taskList = TaskList();
-        self.assertEqual(taskList.taskCount, 0) #Originally no items.
-        taskList.addTask(taskA)
-        taskList.addTask(taskB)
-        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
-
-        taskList.removeTask(taskA)
-        self.assertEqual(taskList.taskCount, 1)
-        taskList.removeTask(taskB)
-        self.assertEqual(taskList.taskCount, 0)
+        self.taskList.removeTask(self.taskA)
+        self.assertEqual(self.taskList.taskCount, 1)
+        self.taskList.removeTask(self.taskB)
+        self.assertEqual(self.taskList.taskCount, 0)
     '''
     def test_sortTaskList(self):
         print("TODO")
@@ -48,6 +52,6 @@ class taskListOperationTests(unittest.TestCase):
     def test_calculateTaskListBestCase(self):
         print("TODO")
 
-    def test_calculateStandardDeviation(self):
+    def test_calculateTaskListStandardDeviation(self):
         print("TODO")
     '''

--- a/python/UnitTest_tasklist.py
+++ b/python/UnitTest_tasklist.py
@@ -1,0 +1,53 @@
+import unittest
+from task import Task
+from tasklist import TaskList
+
+class taskListOperationTests(unittest.TestCase):
+    def test_addTaskToTaskList(self):
+        estimate = 3.0
+        optimistic = 1.0
+        pessimistic = 12.0
+
+        taskA = Task(optimistic, estimate, pessimistic, 3)
+        taskB = Task(1.0, 1.5, 14.0, 4)
+
+        taskList = TaskList();
+        self.assertEqual(taskList.taskCount, 0) #Originally no items.
+        taskList.addTask(taskA)
+        taskList.addTask(taskB)
+        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
+
+    def test_removeTaskFromTaskList(self):
+        estimate = 3.0
+        optimistic = 1.0
+        pessimistic = 12.0
+
+        taskA = Task(optimistic, estimate, pessimistic, 3)
+        taskB = Task(1.0, 1.5, 14.0, 4)
+
+        taskList = TaskList();
+        self.assertEqual(taskList.taskCount, 0) #Originally no items.
+        taskList.addTask(taskA)
+        taskList.addTask(taskB)
+        self.assertEqual(taskList.taskCount, 2) #Now two should exist.
+
+        taskList.removeTask(taskA)
+        self.assertEqual(taskList.taskCount, 1)
+        taskList.removeTask(taskB)
+        self.assertEqual(taskList.taskCount, 0)
+    '''
+    def test_sortTaskList(self):
+        print("TODO")
+
+    def test_calculateTaskListExpected(self):
+        print("TODO")
+
+    def test_calculateTaskListWorstCase(self):
+        print("TODO")
+
+    def test_calculateTaskListBestCase(self):
+        print("TODO")
+
+    def test_calculateStandardDeviation(self):
+        print("TODO")
+    '''

--- a/python/UnitTest_workflow.py
+++ b/python/UnitTest_workflow.py
@@ -4,6 +4,8 @@ from tasklist import TaskList
 
 class workflowOperationTests(unittest.TestCase):
     def setUp(self):
+        self.workflow = Workflow()
+
         self.taskA = Task()
         self.taskB = Task()
         self.taskC = Task()
@@ -16,3 +18,11 @@ class workflowOperationTests(unittest.TestCase):
         self.taskC = None
         self.taskD = None
         self.taskE = None
+
+        self.workflow = None
+
+    def test_addTaskToWorkflow(self):
+
+    def test_addTaskListToWorkflow(self):
+
+    def test_addItemToWorkflow(self):

--- a/python/UnitTest_workflow.py
+++ b/python/UnitTest_workflow.py
@@ -1,0 +1,18 @@
+import unittest
+from task import Task
+from tasklist import TaskList
+
+class workflowOperationTests(unittest.TestCase):
+    def setUp(self):
+        self.taskA = Task()
+        self.taskB = Task()
+        self.taskC = Task()
+        self.taskD = Task()
+        self.taskE = Task()
+
+    def tearDown(self):
+        self.taskA = None
+        self.taskB = None
+        self.taskC = None
+        self.taskD = None
+        self.taskE = None

--- a/python/workflow.py
+++ b/python/workflow.py
@@ -1,1 +1,3 @@
 class Workflow:
+    def __init__(self):
+        self.flowList = list();

--- a/python/workflow.py
+++ b/python/workflow.py
@@ -1,0 +1,1 @@
+class Workflow:

--- a/python/workflow.py
+++ b/python/workflow.py
@@ -1,3 +1,10 @@
 class Workflow:
     def __init__(self):
         self.flowList = list();
+
+    def addTaskToWorkflow(self):
+
+    def addTaskListToWorkflow(self):
+
+    def addItemToWorkflow(self):
+        


### PR DESCRIPTION
As discussed, I have separated out the unit tests into distinct classes for functionality and implemented a UnitTest_main.py file to act as a test driver.

These changes should be pulled into the PERTY_py branch so that others can follow the same approach during development.

These changes are a response to the following issue and the issue needs review:
https://github.com/midmandle/PERTY/issues/15
